### PR TITLE
Bug: Handle GUI window close event properly (#7)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,7 +35,7 @@ int main() {
   auto state = core::createInitialState(context);
   state->onEnter();
 
-  while (!context.quit) {
+  while (!context.quit && context.renderer->isOpen()) {
     char input = '\0';
     if (context.renderer->keyAvailable()) {
       input = context.renderer->getChar();
@@ -44,6 +44,10 @@ int main() {
     state->handleInput(input);
     state->update();
     state->render();
+
+    if (!context.renderer->isOpen()) {
+      break;
+    }
 
     auto nextState = state->takeNextState();
     if (nextState) {

--- a/src/rendering/cli_renderer.cpp
+++ b/src/rendering/cli_renderer.cpp
@@ -23,6 +23,8 @@ bool CLIRenderer::keyAvailable() { return utils::key_available(); }
 
 void CLIRenderer::sleep(int milliseconds) { utils::sleep_ms(milliseconds); }
 
+bool CLIRenderer::isOpen() const { return true; }
+
 void CLIRenderer::showMenu() {
   clear();
   cout << "\t\tPACMAN\n\n\n";

--- a/src/rendering/cli_renderer.h
+++ b/src/rendering/cli_renderer.h
@@ -25,6 +25,7 @@ public:
   char getChar() override;
   bool keyAvailable() override;
   void sleep(int milliseconds) override;
+  bool isOpen() const override;
 
 private:
   void showLeaderboardList();

--- a/src/rendering/gui_renderer.cpp
+++ b/src/rendering/gui_renderer.cpp
@@ -26,6 +26,7 @@ GUIRenderer::GUIRenderer() : lastKeyPressed(0), currentScreen("menu") {
 }
 
 GUIRenderer::~GUIRenderer() {
+  cout << "Closing GUI Renderer..." << endl;
   if (window) {
     window->close();
   }
@@ -97,6 +98,8 @@ bool GUIRenderer::keyAvailable() {
   handleEvents();
   return lastKeyPressed != 0 && window->isOpen();
 }
+
+bool GUIRenderer::isOpen() const { return window ? window->isOpen() : false; }
 
 void GUIRenderer::sleep(int milliseconds) {
   utils::sleep_ms(milliseconds);

--- a/src/rendering/gui_renderer.h
+++ b/src/rendering/gui_renderer.h
@@ -26,6 +26,7 @@ public:
   char getChar() override;
   bool keyAvailable() override;
   void sleep(int milliseconds) override;
+  bool isOpen() const override;
 
 private:
   std::unique_ptr<sf::RenderWindow> window;

--- a/src/rendering/renderer.h
+++ b/src/rendering/renderer.h
@@ -29,6 +29,7 @@ public:
   virtual char getChar() = 0;
   virtual bool keyAvailable() = 0;
   virtual void sleep(int milliseconds) = 0;
+  virtual bool isOpen() const = 0;
 };
 
 } // namespace rendering


### PR DESCRIPTION
This is the bugfix for not closing the app after pressing close button on GUI.  With this change the main loop is checking also if renderer is still open. If not, the loop is breaking and the app is closing gracefully.