### PR TITLE
Refactor: Replace direction representation from char to enum (#4)

### DIFF
--- a/src/core/entity.h
+++ b/src/core/entity.h
@@ -6,6 +6,8 @@
 namespace pacman {
 namespace core {
 
+enum class Direction { NONE, UP, DOWN, LEFT, RIGHT };
+
 class Entity {
 public:
   virtual ~Entity() = default;
@@ -14,9 +16,9 @@ public:
   virtual int y() const = 0;
   virtual int prev_x() const = 0;
   virtual int prev_y() const = 0;
-  virtual char direction() const = 0;
+  virtual Direction direction() const = 0;
   virtual void setPosition(int x, int y) = 0;
-  virtual void setDirection(char direction) = 0;
+  virtual void setDirection(Direction direction) = 0;
   virtual void savePreviousPosition() = 0;
   virtual void move(SMap &map) = 0;
 };

--- a/src/core/game_state.cpp
+++ b/src/core/game_state.cpp
@@ -1,4 +1,5 @@
 #include "core/game_state.h"
+#include "core/entity.h"
 #include "core/game.h"
 #include "core/ghost.h"
 #include "core/map.h"
@@ -19,7 +20,8 @@ class GameOverState;
 class GameplayState : public IGameState {
 public:
   GameplayState(GameContext &ctx, int lvl)
-      : IGameState(ctx), level(lvl), lastInput('\0'), paused(false) {}
+      : IGameState(ctx), level(lvl), lastDirection(Direction::NONE),
+        paused(false) {}
 
   void onEnter() override {
     context.game.state = PLAYING;
@@ -54,7 +56,22 @@ public:
       return;
     }
 
-    lastInput = input;
+    switch (input) {
+    case 'w':
+      lastDirection = Direction::UP;
+      break;
+    case 'a':
+      lastDirection = Direction::LEFT;
+      break;
+    case 's':
+      lastDirection = Direction::DOWN;
+      break;
+    case 'd':
+      lastDirection = Direction::RIGHT;
+      break;
+    default:
+      break;
+    }
   }
 
   void update() override {
@@ -67,8 +84,8 @@ public:
     context.game.ghost3.move(context.game.map);
     context.game.ghost4.move(context.game.map);
 
-    if (lastInput != '\0') {
-      context.game.pman.setDirection(lastInput);
+    if (lastDirection != Direction::NONE) {
+      context.game.pman.setDirection(lastDirection);
     }
     context.game.pman.move(context.game.map);
 
@@ -103,7 +120,7 @@ public:
 
 private:
   int level;
-  char lastInput;
+  Direction lastDirection;
   bool paused;
 };
 

--- a/src/core/ghost.cpp
+++ b/src/core/ghost.cpp
@@ -9,14 +9,14 @@ namespace pacman {
 namespace core {
 
 Ghost::Ghost()
-    : ifcookie(1), last_move('L'), if_boost(0), xg(0), yg(0), prev_xg(0),
-      prev_yg(0), lp(1) {}
+    : ifcookie(1), last_move(Direction::LEFT), if_boost(0), xg(0), yg(0),
+      prev_xg(0), prev_yg(0), lp(1) {}
 
 int Ghost::x() const { return xg; }
 int Ghost::y() const { return yg; }
 int Ghost::prev_x() const { return prev_xg; }
 int Ghost::prev_y() const { return prev_yg; }
-char Ghost::direction() const { return last_move; }
+Direction Ghost::direction() const { return last_move; }
 
 void Ghost::setPosition(int x, int y) {
   xg = x;
@@ -25,7 +25,7 @@ void Ghost::setPosition(int x, int y) {
   prev_yg = y;
 }
 
-void Ghost::setDirection(char direction) { last_move = direction; }
+void Ghost::setDirection(Direction direction) { last_move = direction; }
 
 void Ghost::savePreviousPosition() {
   prev_xg = xg;
@@ -57,7 +57,7 @@ void Ghost::move(SMap &map) {
   }
 
   if (possible > 0) {
-    if (last_move == 'L') {
+    if (last_move == Direction::LEFT) {
       if (left) {
         if (ifcookie != 0) {
           map.map[x][y] = PELLET;
@@ -83,17 +83,17 @@ void Ghost::move(SMap &map) {
         if (ifcookie != 0) {
           map.map[x][y] = PELLET;
           x++;
-          last_move = 'R';
+          last_move = Direction::RIGHT;
         }
         if (if_boost != 0) {
           map.map[x][y] = POWER_UP;
           x++;
-          last_move = 'R';
+          last_move = Direction::RIGHT;
         }
         if (ifcookie == 0 && if_boost == 0) {
           map.map[x][y] = EMPTY;
           x++;
-          last_move = 'R';
+          last_move = Direction::RIGHT;
         }
         if (map.map[x][y] == PELLET)
           ifcookie = 1;
@@ -107,17 +107,17 @@ void Ghost::move(SMap &map) {
         if (ifcookie != 0) {
           map.map[x][y] = PELLET;
           x--;
-          last_move = 'U';
+          last_move = Direction::UP;
         }
         if (if_boost != 0) {
           map.map[x][y] = POWER_UP;
           x--;
-          last_move = 'U';
+          last_move = Direction::UP;
         }
         if (ifcookie == 0 && if_boost == 0) {
           map.map[x][y] = EMPTY;
           x--;
-          last_move = 'U';
+          last_move = Direction::UP;
         }
         if (map.map[x][y] == PELLET)
           ifcookie = 1;
@@ -131,17 +131,17 @@ void Ghost::move(SMap &map) {
         if (ifcookie != 0) {
           map.map[x][y] = PELLET;
           y++;
-          last_move = 'D';
+          last_move = Direction::DOWN;
         }
         if (if_boost != 0) {
           map.map[x][y] = POWER_UP;
           y++;
-          last_move = 'D';
+          last_move = Direction::DOWN;
         }
         if (ifcookie == 0 && if_boost == 0) {
           map.map[x][y] = EMPTY;
           y++;
-          last_move = 'D';
+          last_move = Direction::DOWN;
         }
         if (map.map[x][y] == PELLET)
           ifcookie = 1;
@@ -152,7 +152,7 @@ void Ghost::move(SMap &map) {
         else
           if_boost = 0;
       }
-    } else if (last_move == 'R') {
+    } else if (last_move == Direction::RIGHT) {
       if (right) {
         if (ifcookie != 0) {
           map.map[x][y] = PELLET;
@@ -178,17 +178,17 @@ void Ghost::move(SMap &map) {
         if (ifcookie != 0) {
           map.map[x][y] = PELLET;
           x++;
-          last_move = 'R';
+          last_move = Direction::RIGHT;
         }
         if (if_boost != 0) {
           map.map[x][y] = POWER_UP;
           x++;
-          last_move = 'R';
+          last_move = Direction::RIGHT;
         }
         if (ifcookie == 0 && if_boost == 0) {
           map.map[x][y] = EMPTY;
           x++;
-          last_move = 'R';
+          last_move = Direction::RIGHT;
         }
         if (map.map[x][y] == PELLET)
           ifcookie = 1;
@@ -202,17 +202,17 @@ void Ghost::move(SMap &map) {
         if (ifcookie != 0) {
           map.map[x][y] = PELLET;
           x--;
-          last_move = 'U';
+          last_move = Direction::UP;
         }
         if (if_boost != 0) {
           map.map[x][y] = POWER_UP;
           x--;
-          last_move = 'U';
+          last_move = Direction::UP;
         }
         if (ifcookie == 0 && if_boost == 0) {
           map.map[x][y] = EMPTY;
           x--;
-          last_move = 'U';
+          last_move = Direction::UP;
         }
         if (map.map[x][y] == PELLET)
           ifcookie = 1;
@@ -226,17 +226,17 @@ void Ghost::move(SMap &map) {
         if (ifcookie != 0) {
           map.map[x][y] = PELLET;
           y--;
-          last_move = 'D';
+          last_move = Direction::DOWN;
         }
         if (if_boost != 0) {
           map.map[x][y] = POWER_UP;
           y--;
-          last_move = 'D';
+          last_move = Direction::DOWN;
         }
         if (ifcookie == 0 && if_boost == 0) {
           map.map[x][y] = EMPTY;
           y--;
-          last_move = 'D';
+          last_move = Direction::DOWN;
         }
         if (map.map[x][y] == PELLET)
           ifcookie = 1;
@@ -247,7 +247,7 @@ void Ghost::move(SMap &map) {
         else
           if_boost = 0;
       }
-    } else if (last_move == 'U') {
+    } else if (last_move == Direction::UP) {
       if (up) {
         if (ifcookie != 0) {
           map.map[x][y] = PELLET;
@@ -273,17 +273,17 @@ void Ghost::move(SMap &map) {
         if (ifcookie != 0) {
           map.map[x][y] = PELLET;
           y++;
-          last_move = 'R';
+          last_move = Direction::RIGHT;
         }
         if (if_boost != 0) {
           map.map[x][y] = POWER_UP;
           y++;
-          last_move = 'R';
+          last_move = Direction::RIGHT;
         }
         if (ifcookie == 0 && if_boost == 0) {
           map.map[x][y] = EMPTY;
           y++;
-          last_move = 'R';
+          last_move = Direction::RIGHT;
         }
         if (map.map[x][y] == PELLET)
           ifcookie = 1;
@@ -297,17 +297,17 @@ void Ghost::move(SMap &map) {
         if (ifcookie != 0) {
           map.map[x][y] = PELLET;
           y--;
-          last_move = 'L';
+          last_move = Direction::LEFT;
         }
         if (if_boost != 0) {
           map.map[x][y] = POWER_UP;
           y--;
-          last_move = 'L';
+          last_move = Direction::LEFT;
         }
         if (ifcookie == 0 && if_boost == 0) {
           map.map[x][y] = EMPTY;
           y--;
-          last_move = 'L';
+          last_move = Direction::LEFT;
         }
         if (map.map[x][y] == PELLET)
           ifcookie = 1;
@@ -321,17 +321,17 @@ void Ghost::move(SMap &map) {
         if (ifcookie != 0) {
           map.map[x][y] = PELLET;
           x++;
-          last_move = 'D';
+          last_move = Direction::DOWN;
         }
         if (if_boost != 0) {
           map.map[x][y] = POWER_UP;
           x++;
-          last_move = 'D';
+          last_move = Direction::DOWN;
         }
         if (ifcookie == 0 && if_boost == 0) {
           map.map[x][y] = EMPTY;
           x++;
-          last_move = 'D';
+          last_move = Direction::DOWN;
         }
         if (map.map[x][y] == PELLET)
           ifcookie = 1;
@@ -342,7 +342,7 @@ void Ghost::move(SMap &map) {
         else
           if_boost = 0;
       }
-    } else if (last_move == 'D') {
+    } else if (last_move == Direction::DOWN) {
       if (down) {
         if (ifcookie != 0) {
           map.map[x][y] = PELLET;
@@ -368,17 +368,17 @@ void Ghost::move(SMap &map) {
         if (ifcookie != 0) {
           map.map[x][y] = PELLET;
           y--;
-          last_move = 'L';
+          last_move = Direction::LEFT;
         }
         if (if_boost != 0) {
           map.map[x][y] = POWER_UP;
           y--;
-          last_move = 'L';
+          last_move = Direction::LEFT;
         }
         if (ifcookie == 0 && if_boost == 0) {
           map.map[x][y] = EMPTY;
           y--;
-          last_move = 'L';
+          last_move = Direction::LEFT;
         }
         if (map.map[x][y] == PELLET)
           ifcookie = 1;
@@ -392,17 +392,17 @@ void Ghost::move(SMap &map) {
         if (ifcookie != 0) {
           map.map[x][y] = PELLET;
           y++;
-          last_move = 'R';
+          last_move = Direction::RIGHT;
         }
         if (if_boost != 0) {
           map.map[x][y] = POWER_UP;
           y++;
-          last_move = 'R';
+          last_move = Direction::RIGHT;
         }
         if (ifcookie == 0 && if_boost == 0) {
           map.map[x][y] = EMPTY;
           y++;
-          last_move = 'R';
+          last_move = Direction::RIGHT;
         }
         if (map.map[x][y] == PELLET)
           ifcookie = 1;
@@ -416,17 +416,17 @@ void Ghost::move(SMap &map) {
         if (ifcookie != 0) {
           map.map[x][y] = PELLET;
           x--;
-          last_move = 'U';
+          last_move = Direction::UP;
         }
         if (if_boost != 0) {
           map.map[x][y] = POWER_UP;
           x--;
-          last_move = 'U';
+          last_move = Direction::UP;
         }
         if (ifcookie == 0 && if_boost == 0) {
           map.map[x][y] = EMPTY;
           x--;
-          last_move = 'U';
+          last_move = Direction::UP;
         }
         if (map.map[x][y] == PELLET)
           ifcookie = 1;

--- a/src/core/ghost.h
+++ b/src/core/ghost.h
@@ -14,14 +14,14 @@ public:
   int y() const override;
   int prev_x() const override;
   int prev_y() const override;
-  char direction() const override;
+  Direction direction() const override;
   void setPosition(int x, int y) override;
-  void setDirection(char direction) override;
+  void setDirection(Direction direction) override;
   void savePreviousPosition() override;
   void move(SMap &map) override;
 
   int ifcookie;
-  char last_move;
+  Direction last_move;
   int if_boost;
   int xg, yg, prev_xg, prev_yg, lp;
 };

--- a/src/core/pman.cpp
+++ b/src/core/pman.cpp
@@ -8,20 +8,20 @@ namespace core {
 
 Pacman::Pacman()
     : lives(0), points(0), xp_(0), yp_(0), prev_xp_(0), prev_yp_(0),
-      direction_('\0') {}
+      direction_(Direction::NONE) {}
 
 int Pacman::x() const { return xp_; }
 int Pacman::y() const { return yp_; }
 int Pacman::prev_x() const { return prev_xp_; }
 int Pacman::prev_y() const { return prev_yp_; }
-char Pacman::direction() const { return direction_; }
+Direction Pacman::direction() const { return direction_; }
 
 void Pacman::setPosition(int x, int y) {
   xp_ = x;
   yp_ = y;
 }
 
-void Pacman::setDirection(char direction) { direction_ = direction; }
+void Pacman::setDirection(Direction direction) { direction_ = direction; }
 
 void Pacman::savePreviousPosition() {
   prev_xp_ = xp_;
@@ -40,7 +40,7 @@ void Pacman::move(SMap &map) {
     yp_ = map.yp;
   }
 
-  if (direction_ == '\0') {
+  if (direction_ == Direction::NONE) {
     return;
   }
 
@@ -49,7 +49,7 @@ void Pacman::move(SMap &map) {
   int yp = yp_;
 
   switch (direction_) {
-  case 'a':
+  case Direction::LEFT:
     if (xp == 8 && yp == 0) {
       map.map[xp][yp] = EMPTY;
       if (map.map[8][19] == PELLET)
@@ -75,7 +75,7 @@ void Pacman::move(SMap &map) {
     }
     break;
 
-  case 'w':
+  case Direction::UP:
     if (map.map[xp - 1][yp] != WALL) {
       if (map.map[xp - 1][yp] == PELLET) {
         currentPoints++;
@@ -94,7 +94,7 @@ void Pacman::move(SMap &map) {
     }
     break;
 
-  case 's':
+  case Direction::DOWN:
     if (map.map[xp + 1][yp] != WALL) {
       if (map.map[xp + 1][yp] == PELLET) {
         currentPoints++;
@@ -113,7 +113,7 @@ void Pacman::move(SMap &map) {
     }
     break;
 
-  case 'd':
+  case Direction::RIGHT:
     if (xp == 8 && yp == 19) {
       map.map[xp][yp] = EMPTY;
       if (map.map[8][0] == PELLET)

--- a/src/core/pman.h
+++ b/src/core/pman.h
@@ -14,9 +14,9 @@ public:
   int y() const override;
   int prev_x() const override;
   int prev_y() const override;
-  char direction() const override;
+  Direction direction() const override;
   void setPosition(int x, int y) override;
-  void setDirection(char direction) override;
+  void setDirection(Direction direction) override;
   void savePreviousPosition() override;
   void move(SMap &map) override;
 
@@ -28,7 +28,7 @@ private:
   int yp_;
   int prev_xp_;
   int prev_yp_;
-  char direction_;
+  Direction direction_;
 };
 
 } // namespace core


### PR DESCRIPTION
## Description
Up to this point direction of Ghosts and Pacman movement was represented by char. With this change, new enum Direction is introduced, that has following values: NONE, UP, DOWN, LEFT, RIGHT