### PR TITLE
Refactor: Remove entity positions from Map (#29)

### DIFF
--- a/src/core/game.cpp
+++ b/src/core/game.cpp
@@ -23,16 +23,16 @@ void game_count(SGame &game) {
   if ((game.ghost1.x() == game.pman.x() && game.ghost1.y() == game.pman.y()) ||
       (game.ghost2.x() == game.pman.x() && game.ghost2.y() == game.pman.y())) {
     game.pman.lives--;
-    game.pman.setPosition(game.map.start_xp, game.map.start_yp);
-    game.map.xp = game.map.start_xp;
-    game.map.yp = game.map.start_yp;
-    game.map.map[game.map.xp][game.map.yp] = core::PACMAN_PLAYER;
+    game.pman.setPosition(game.pman.spawnX, game.pman.spawnY);
+    game.map.map[game.pman.spawnX][game.pman.spawnY] = core::PACMAN_PLAYER;
   }
 }
 
 void game_init(SGame &game, const GameConfig &config) {
   init_map(game.map, config);
   game.pman = Pacman();
+  game.pman.spawnX = config.pacmanStartX;
+  game.pman.spawnY = config.pacmanStartY;
   game.pman.setPosition(config.pacmanStartX, config.pacmanStartY);
   game.pman.savePreviousPosition();
   game.timer = config.startingTimerMs;

--- a/src/core/game_state.cpp
+++ b/src/core/game_state.cpp
@@ -33,6 +33,8 @@ public:
     } else {
       map_create2(context.game.map);
     }
+    context.game.map.map[context.game.pman.x()][context.game.pman.y()] =
+        PACMAN_PLAYER;
 
     game_count(context.game);
   }

--- a/src/core/ghost.cpp
+++ b/src/core/ghost.cpp
@@ -10,7 +10,7 @@ namespace core {
 
 Ghost::Ghost()
     : ifcookie(1), last_move(Direction::LEFT), if_boost(0), xg(0), yg(0),
-      prev_xg(0), prev_yg(0), lp(1) {}
+      prev_xg(0), prev_yg(0) {}
 
 int Ghost::x() const { return xg; }
 int Ghost::y() const { return yg; }
@@ -444,18 +444,6 @@ void Ghost::move(SMap &map) {
   yg = y;
 
   map.map[xg][yg] = GHOST;
-
-  if (1) {
-    if (lp % 2 != 0) {
-      map.xg1 = xg;
-      map.yg1 = yg;
-    }
-    if (lp % 2 == 0) {
-      map.xg2 = xg;
-      map.yg2 = yg;
-    }
-    lp++;
-  }
 }
 
 } // namespace core

--- a/src/core/ghost.h
+++ b/src/core/ghost.h
@@ -23,7 +23,7 @@ public:
   int ifcookie;
   Direction last_move;
   int if_boost;
-  int xg, yg, prev_xg, prev_yg, lp;
+  int xg, yg, prev_xg, prev_yg;
 };
 
 } // namespace core

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -12,15 +12,9 @@ void init_map(SMap &map, const GameConfig &config) {
   map.width = config.mapWidth;
   map.height = config.mapHeight;
   map.powerUpScore = config.powerUpScore;
-  map.start_xp = config.pacmanStartX;
-  map.start_yp = config.pacmanStartY;
-  map.xp = map.start_xp;
-  map.yp = map.start_yp;
 }
 
 void map_create1(SMap &map) {
-  int xp = map.xp, yp = map.yp;
-
   for (int i = 0; i < map.height; i++) {
     for (int j = 0; j < map.width; j++) {
       map.map[i][j] = WALL;
@@ -85,12 +79,9 @@ void map_create1(SMap &map) {
   map.map[14][12] = WALL;
   map.map[14][14] = WALL;
 
-  map.map[xp][yp] = PACMAN_PLAYER;
 }
 
 void map_create2(SMap &map) {
-  int xp = map.xp, yp = map.yp;
-
   for (int i = 0; i < map.height; i++) {
     for (int j = 0; j < map.width; j++) {
       map.map[i][j] = WALL;
@@ -175,8 +166,6 @@ void map_create2(SMap &map) {
   map.map[13][9] = PELLET;
   map.map[13][10] = PELLET;
   map.map[13][11] = PELLET;
-
-  map.map[xp][yp] = PACMAN_PLAYER;
 }
 
 void map_create3(SMap &map) {
@@ -263,7 +252,6 @@ void map_create3(SMap &map) {
   map.map[1][18] = POWER_UP;
   map.map[15][18] = POWER_UP;
 
-  map.map[map.xp][map.yp] = PACMAN_PLAYER;
 }
 
 void map_show(SMap map) {

--- a/src/core/map.h
+++ b/src/core/map.h
@@ -16,7 +16,6 @@ struct SMap {
   int width;
   int height;
   int powerUpScore;
-  int xp, yp, start_xp, start_yp, xg1, yg1, xg2, yg2;
 };
 
 void init_map(SMap &map, const GameConfig &config);

--- a/src/core/pman.cpp
+++ b/src/core/pman.cpp
@@ -7,8 +7,8 @@ namespace pacman {
 namespace core {
 
 Pacman::Pacman()
-    : lives(0), points(0), xp_(0), yp_(0), prev_xp_(0), prev_yp_(0),
-      direction_(Direction::NONE) {}
+    : lives(0), points(0), spawnX(0), spawnY(0), xp_(0), yp_(0), prev_xp_(0),
+      prev_yp_(0), direction_(Direction::NONE) {}
 
 int Pacman::x() const { return xp_; }
 int Pacman::y() const { return yp_; }
@@ -34,10 +34,8 @@ void Pacman::move(SMap &map) {
   if (map.map[xp_][yp_] == GHOST) {
     lives--;
     map.map[xp_][yp_] = GHOST;
-    map.xp = map.start_xp;
-    map.yp = map.start_yp;
-    xp_ = map.xp;
-    yp_ = map.yp;
+    xp_ = spawnX;
+    yp_ = spawnY;
   }
 
   if (direction_ == Direction::NONE) {
@@ -67,8 +65,8 @@ void Pacman::move(SMap &map) {
       if (map.map[xp][yp - 1] == GHOST) {
         lives--;
         map.map[xp][yp] = EMPTY;
-        xp = map.start_xp;
-        yp = map.start_yp;
+        xp = spawnX;
+        yp = spawnY;
       }
       map.map[xp][yp] = EMPTY;
       yp--;
@@ -86,8 +84,8 @@ void Pacman::move(SMap &map) {
       if (map.map[xp - 1][yp] == GHOST) {
         lives--;
         map.map[xp][yp] = EMPTY;
-        xp = map.start_xp;
-        yp = map.start_yp;
+        xp = spawnX;
+        yp = spawnY;
       }
       map.map[xp][yp] = EMPTY;
       xp--;
@@ -105,8 +103,8 @@ void Pacman::move(SMap &map) {
       if (map.map[xp + 1][yp] == GHOST) {
         lives--;
         map.map[xp][yp] = EMPTY;
-        xp = map.start_xp;
-        yp = map.start_yp;
+        xp = spawnX;
+        yp = spawnY;
       }
       map.map[xp][yp] = EMPTY;
       xp++;
@@ -131,8 +129,8 @@ void Pacman::move(SMap &map) {
       if (map.map[xp][yp + 1] == GHOST) {
         lives--;
         map.map[xp][yp] = EMPTY;
-        xp = map.start_xp;
-        yp = map.start_yp;
+        xp = spawnX;
+        yp = spawnY;
       }
       map.map[xp][yp] = EMPTY;
       yp++;
@@ -146,13 +144,11 @@ void Pacman::move(SMap &map) {
   if (map.map[xp][yp] == GHOST) {
     lives--;
     map.map[xp][yp] = GHOST;
-    xp = map.start_xp;
-    yp = map.start_yp;
+    xp = spawnX;
+    yp = spawnY;
   }
 
   map.map[xp][yp] = PACMAN_PLAYER;
-  map.xp = xp;
-  map.yp = yp;
   xp_ = xp;
   yp_ = yp;
   points = currentPoints;

--- a/src/core/pman.h
+++ b/src/core/pman.h
@@ -22,6 +22,8 @@ public:
 
   int lives;
   int points;
+  int spawnX;
+  int spawnY;
 
 private:
   int xp_;


### PR DESCRIPTION
With this change entity positions have been removed from Map. They are only covered by Ghost and Pacman structures.