### PR TITLE
Refactor: Simplify ghost movement and make it random (#30)

### DIFF
--- a/src/core/ghost.cpp
+++ b/src/core/ghost.cpp
@@ -1,16 +1,12 @@
 #include "core/ghost.h"
-#include <cstdlib>
-#include <ctime>
-#include <iostream>
-
-using namespace std;
+#include <array>
+#include <vector>
 
 namespace pacman {
 namespace core {
 
 Ghost::Ghost()
-    : ifcookie(1), last_move(Direction::LEFT), if_boost(0), xg(0), yg(0),
-      prev_xg(0), prev_yg(0) {}
+    : last_move(Direction::LEFT), xg(0), yg(0), prev_xg(0), prev_yg(0) {}
 
 int Ghost::x() const { return xg; }
 int Ghost::y() const { return yg; }
@@ -32,418 +28,72 @@ void Ghost::savePreviousPosition() {
   prev_yg = yg;
 }
 
+namespace {
+
+struct MovePlan {
+  int dx;
+  int dy;
+  Direction dir;
+};
+
+constexpr std::array<MovePlan, 4> ALL_MOVES = {{
+    {-1, 0, Direction::UP},
+    {1, 0, Direction::DOWN},
+    {0, -1, Direction::LEFT},
+    {0, 1, Direction::RIGHT},
+}};
+
+bool isTileAvailable(const SMap &map, int x, int y) {
+  return map.map[x][y] != WALL;
+}
+
+Direction reverseOf(Direction dir) {
+  switch (dir) {
+  case Direction::UP:
+    return Direction::DOWN;
+  case Direction::DOWN:
+    return Direction::UP;
+  case Direction::LEFT:
+    return Direction::RIGHT;
+  case Direction::RIGHT:
+    return Direction::LEFT;
+  default:
+    return Direction::NONE;
+  }
+}
+
+} // namespace
+
 MapObjectType Ghost::move(SMap &map) {
   savePreviousPosition();
-  int x = xg, y = yg;
 
-  int possible = 0;
-  int up = 0, down = 0, left = 0, right = 0;
+  Direction reverse = reverseOf(last_move);
+  std::vector<MovePlan> candidates;
 
-  if (map.map[x - 1][y] != WALL && map.map[x - 1][y] != GHOST) {
-    possible++;
-    up = 1;
-  }
-  if (map.map[x + 1][y] != WALL && map.map[x + 1][y] != GHOST) {
-    possible++;
-    down = 1;
-  }
-  if (map.map[x][y - 1] != WALL && map.map[x][y - 1] != GHOST) {
-    possible++;
-    left = 1;
-  }
-  if (map.map[x][y + 1] != WALL && map.map[x][y + 1] != GHOST) {
-    possible++;
-    right = 1;
+  for (const MovePlan &m : ALL_MOVES) {
+    if (m.dir != reverse && isTileAvailable(map, xg + m.dx, yg + m.dy))
+      candidates.push_back(m);
   }
 
-  if (possible > 0) {
-    if (last_move == Direction::LEFT) {
-      if (left) {
-        if (ifcookie != 0) {
-          map.map[x][y] = PELLET;
-          y--;
-        }
-        if (if_boost != 0) {
-          map.map[x][y] = POWER_UP;
-          y--;
-        }
-        if (ifcookie == 0 && if_boost == 0) {
-          map.map[x][y] = EMPTY;
-          y--;
-        }
-        if (map.map[x][y] == PELLET)
-          ifcookie = 1;
-        else
-          ifcookie = 0;
-        if (map.map[x][y] == POWER_UP)
-          if_boost = 1;
-        else
-          if_boost = 0;
-      } else if (down) {
-        if (ifcookie != 0) {
-          map.map[x][y] = PELLET;
-          x++;
-          last_move = Direction::RIGHT;
-        }
-        if (if_boost != 0) {
-          map.map[x][y] = POWER_UP;
-          x++;
-          last_move = Direction::RIGHT;
-        }
-        if (ifcookie == 0 && if_boost == 0) {
-          map.map[x][y] = EMPTY;
-          x++;
-          last_move = Direction::RIGHT;
-        }
-        if (map.map[x][y] == PELLET)
-          ifcookie = 1;
-        else
-          ifcookie = 0;
-        if (map.map[x][y] == POWER_UP)
-          if_boost = 1;
-        else
-          if_boost = 0;
-      } else if (up) {
-        if (ifcookie != 0) {
-          map.map[x][y] = PELLET;
-          x--;
-          last_move = Direction::UP;
-        }
-        if (if_boost != 0) {
-          map.map[x][y] = POWER_UP;
-          x--;
-          last_move = Direction::UP;
-        }
-        if (ifcookie == 0 && if_boost == 0) {
-          map.map[x][y] = EMPTY;
-          x--;
-          last_move = Direction::UP;
-        }
-        if (map.map[x][y] == PELLET)
-          ifcookie = 1;
-        else
-          ifcookie = 0;
-        if (map.map[x][y] == POWER_UP)
-          if_boost = 1;
-        else
-          if_boost = 0;
-      } else if (right) {
-        if (ifcookie != 0) {
-          map.map[x][y] = PELLET;
-          y++;
-          last_move = Direction::DOWN;
-        }
-        if (if_boost != 0) {
-          map.map[x][y] = POWER_UP;
-          y++;
-          last_move = Direction::DOWN;
-        }
-        if (ifcookie == 0 && if_boost == 0) {
-          map.map[x][y] = EMPTY;
-          y++;
-          last_move = Direction::DOWN;
-        }
-        if (map.map[x][y] == PELLET)
-          ifcookie = 1;
-        else
-          ifcookie = 0;
-        if (map.map[x][y] == POWER_UP)
-          if_boost = 1;
-        else
-          if_boost = 0;
-      }
-    } else if (last_move == Direction::RIGHT) {
-      if (right) {
-        if (ifcookie != 0) {
-          map.map[x][y] = PELLET;
-          y++;
-        }
-        if (if_boost != 0) {
-          map.map[x][y] = POWER_UP;
-          y++;
-        }
-        if (ifcookie == 0 && if_boost == 0) {
-          map.map[x][y] = EMPTY;
-          y++;
-        }
-        if (map.map[x][y] == PELLET)
-          ifcookie = 1;
-        else
-          ifcookie = 0;
-        if (map.map[x][y] == POWER_UP)
-          if_boost = 1;
-        else
-          if_boost = 0;
-      } else if (down) {
-        if (ifcookie != 0) {
-          map.map[x][y] = PELLET;
-          x++;
-          last_move = Direction::RIGHT;
-        }
-        if (if_boost != 0) {
-          map.map[x][y] = POWER_UP;
-          x++;
-          last_move = Direction::RIGHT;
-        }
-        if (ifcookie == 0 && if_boost == 0) {
-          map.map[x][y] = EMPTY;
-          x++;
-          last_move = Direction::RIGHT;
-        }
-        if (map.map[x][y] == PELLET)
-          ifcookie = 1;
-        else
-          ifcookie = 0;
-        if (map.map[x][y] == POWER_UP)
-          if_boost = 1;
-        else
-          if_boost = 0;
-      } else if (up) {
-        if (ifcookie != 0) {
-          map.map[x][y] = PELLET;
-          x--;
-          last_move = Direction::UP;
-        }
-        if (if_boost != 0) {
-          map.map[x][y] = POWER_UP;
-          x--;
-          last_move = Direction::UP;
-        }
-        if (ifcookie == 0 && if_boost == 0) {
-          map.map[x][y] = EMPTY;
-          x--;
-          last_move = Direction::UP;
-        }
-        if (map.map[x][y] == PELLET)
-          ifcookie = 1;
-        else
-          ifcookie = 0;
-        if (map.map[x][y] == POWER_UP)
-          if_boost = 1;
-        else
-          if_boost = 0;
-      } else if (left) {
-        if (ifcookie != 0) {
-          map.map[x][y] = PELLET;
-          y--;
-          last_move = Direction::DOWN;
-        }
-        if (if_boost != 0) {
-          map.map[x][y] = POWER_UP;
-          y--;
-          last_move = Direction::DOWN;
-        }
-        if (ifcookie == 0 && if_boost == 0) {
-          map.map[x][y] = EMPTY;
-          y--;
-          last_move = Direction::DOWN;
-        }
-        if (map.map[x][y] == PELLET)
-          ifcookie = 1;
-        else
-          ifcookie = 0;
-        if (map.map[x][y] == POWER_UP)
-          if_boost = 1;
-        else
-          if_boost = 0;
-      }
-    } else if (last_move == Direction::UP) {
-      if (up) {
-        if (ifcookie != 0) {
-          map.map[x][y] = PELLET;
-          x--;
-        }
-        if (if_boost != 0) {
-          map.map[x][y] = POWER_UP;
-          x--;
-        }
-        if (ifcookie == 0 && if_boost == 0) {
-          map.map[x][y] = EMPTY;
-          x--;
-        }
-        if (map.map[x][y] == PELLET)
-          ifcookie = 1;
-        else
-          ifcookie = 0;
-        if (map.map[x][y] == POWER_UP)
-          if_boost = 1;
-        else
-          if_boost = 0;
-      } else if (right) {
-        if (ifcookie != 0) {
-          map.map[x][y] = PELLET;
-          y++;
-          last_move = Direction::RIGHT;
-        }
-        if (if_boost != 0) {
-          map.map[x][y] = POWER_UP;
-          y++;
-          last_move = Direction::RIGHT;
-        }
-        if (ifcookie == 0 && if_boost == 0) {
-          map.map[x][y] = EMPTY;
-          y++;
-          last_move = Direction::RIGHT;
-        }
-        if (map.map[x][y] == PELLET)
-          ifcookie = 1;
-        else
-          ifcookie = 0;
-        if (map.map[x][y] == POWER_UP)
-          if_boost = 1;
-        else
-          if_boost = 0;
-      } else if (left) {
-        if (ifcookie != 0) {
-          map.map[x][y] = PELLET;
-          y--;
-          last_move = Direction::LEFT;
-        }
-        if (if_boost != 0) {
-          map.map[x][y] = POWER_UP;
-          y--;
-          last_move = Direction::LEFT;
-        }
-        if (ifcookie == 0 && if_boost == 0) {
-          map.map[x][y] = EMPTY;
-          y--;
-          last_move = Direction::LEFT;
-        }
-        if (map.map[x][y] == PELLET)
-          ifcookie = 1;
-        else
-          ifcookie = 0;
-        if (map.map[x][y] == POWER_UP)
-          if_boost = 1;
-        else
-          if_boost = 0;
-      } else if (down) {
-        if (ifcookie != 0) {
-          map.map[x][y] = PELLET;
-          x++;
-          last_move = Direction::DOWN;
-        }
-        if (if_boost != 0) {
-          map.map[x][y] = POWER_UP;
-          x++;
-          last_move = Direction::DOWN;
-        }
-        if (ifcookie == 0 && if_boost == 0) {
-          map.map[x][y] = EMPTY;
-          x++;
-          last_move = Direction::DOWN;
-        }
-        if (map.map[x][y] == PELLET)
-          ifcookie = 1;
-        else
-          ifcookie = 0;
-        if (map.map[x][y] == POWER_UP)
-          if_boost = 1;
-        else
-          if_boost = 0;
-      }
-    } else if (last_move == Direction::DOWN) {
-      if (down) {
-        if (ifcookie != 0) {
-          map.map[x][y] = PELLET;
-          x++;
-        }
-        if (if_boost != 0) {
-          map.map[x][y] = POWER_UP;
-          x++;
-        }
-        if (ifcookie == 0 && if_boost == 0) {
-          map.map[x][y] = EMPTY;
-          x++;
-        }
-        if (map.map[x][y] == PELLET)
-          ifcookie = 1;
-        else
-          ifcookie = 0;
-        if (map.map[x][y] == POWER_UP)
-          if_boost = 1;
-        else
-          if_boost = 0;
-      } else if (left) {
-        if (ifcookie != 0) {
-          map.map[x][y] = PELLET;
-          y--;
-          last_move = Direction::LEFT;
-        }
-        if (if_boost != 0) {
-          map.map[x][y] = POWER_UP;
-          y--;
-          last_move = Direction::LEFT;
-        }
-        if (ifcookie == 0 && if_boost == 0) {
-          map.map[x][y] = EMPTY;
-          y--;
-          last_move = Direction::LEFT;
-        }
-        if (map.map[x][y] == PELLET)
-          ifcookie = 1;
-        else
-          ifcookie = 0;
-        if (map.map[x][y] == POWER_UP)
-          if_boost = 1;
-        else
-          if_boost = 0;
-      } else if (right) {
-        if (ifcookie != 0) {
-          map.map[x][y] = PELLET;
-          y++;
-          last_move = Direction::RIGHT;
-        }
-        if (if_boost != 0) {
-          map.map[x][y] = POWER_UP;
-          y++;
-          last_move = Direction::RIGHT;
-        }
-        if (ifcookie == 0 && if_boost == 0) {
-          map.map[x][y] = EMPTY;
-          y++;
-          last_move = Direction::RIGHT;
-        }
-        if (map.map[x][y] == PELLET)
-          ifcookie = 1;
-        else
-          ifcookie = 0;
-        if (map.map[x][y] == POWER_UP)
-          if_boost = 1;
-        else
-          if_boost = 0;
-      } else if (up) {
-        if (ifcookie != 0) {
-          map.map[x][y] = PELLET;
-          x--;
-          last_move = Direction::UP;
-        }
-        if (if_boost != 0) {
-          map.map[x][y] = POWER_UP;
-          x--;
-          last_move = Direction::UP;
-        }
-        if (ifcookie == 0 && if_boost == 0) {
-          map.map[x][y] = EMPTY;
-          x--;
-          last_move = Direction::UP;
-        }
-        if (map.map[x][y] == PELLET)
-          ifcookie = 1;
-        else
-          ifcookie = 0;
-        if (map.map[x][y] == POWER_UP)
-          if_boost = 1;
-        else
-          if_boost = 0;
-      }
+  // At a dead end allow reversing
+  if (candidates.empty()) {
+    for (const MovePlan &m : ALL_MOVES) {
+      if (isTileAvailable(map, xg + m.dx, yg + m.dy))
+        candidates.push_back(m);
     }
   }
 
-  xg = x;
-  yg = y;
+  if (candidates.empty())
+    return EMPTY;
 
-  map.map[xg][yg] = GHOST;
+  // No crossroad: only one option, take it; crossroad: pick randomly
+  const MovePlan &chosen = candidates.size() == 1
+                               ? candidates[0]
+                               : candidates[std::rand() % candidates.size()];
+
+  xg += chosen.dx;
+  yg += chosen.dy;
+  last_move = chosen.dir;
   return EMPTY;
 }
 

--- a/src/core/ghost.h
+++ b/src/core/ghost.h
@@ -20,9 +20,7 @@ public:
   void savePreviousPosition() override;
   MapObjectType move(SMap &map) override;
 
-  int ifcookie;
   Direction last_move;
-  int if_boost;
   int xg, yg, prev_xg, prev_yg;
 };
 

--- a/src/rendering/cli_renderer.cpp
+++ b/src/rendering/cli_renderer.cpp
@@ -39,7 +39,24 @@ void CLIRenderer::showMenu() {
 void CLIRenderer::showGameState(const core::SGame &game,
                                 double /* interpolation */) {
   clear();
-  showMap(game.map);
+
+  char display[17][20];
+  for (int i = 0; i < 17; i++)
+    for (int j = 0; j < 20; j++)
+      display[i][j] = mapObjectTypeToChar(game.map.map[i][j]);
+
+  const core::Ghost *ghosts[] = {&game.ghost1, &game.ghost2, &game.ghost3,
+                                 &game.ghost4};
+  for (const core::Ghost *g : ghosts)
+    display[g->x()][g->y()] = 'A';
+  display[game.pman.x()][game.pman.y()] = 'O';
+
+  for (int i = 0; i < 17; i++) {
+    for (int j = 0; j < 20; j++)
+      cout << setw(2) << display[i][j];
+    cout << "\n";
+  }
+
   showGameCounter(game);
 }
 
@@ -73,16 +90,7 @@ char CLIRenderer::mapObjectTypeToChar(core::MapObjectType type) {
 void CLIRenderer::showGameCounter(const core::SGame &game) {
   cout << "Time remaining: " << game.timer / 1000 << "\n\n";
   cout << "Points: " << game.pman.points << "\n\n";
-
-  int food_count = 0;
-  for (int i = 0; i < 17; i++) {
-    for (int j = 0; j < 20; j++) {
-      if (game.map.map[i][j] == core::PELLET ||
-          game.map.map[i][j] == core::POWER_UP)
-        food_count++;
-    }
-  }
-  cout << "Food count: " << food_count << "\n\n";
+  cout << "Food count: " << game.food << "\n\n";
   cout << "Lives: " << game.pman.lives << "\n\n";
 }
 

--- a/src/rendering/gui_renderer.cpp
+++ b/src/rendering/gui_renderer.cpp
@@ -270,18 +270,9 @@ void GUIRenderer::drawGameUI(const core::SGame &game, sf::RenderWindow &win) {
   ss << "Lives: " << game.pman.lives;
   drawText(ss.str(), 10, config.windowHeight + 45, 12, sf::Color::Yellow, win);
 
-  int food_count = 0;
-  for (int i = 0; i < config.mapHeight; i++) {
-    for (int j = 0; j < config.mapWidth; j++) {
-      if (game.map.map[i][j] == core::PELLET ||
-          game.map.map[i][j] == core::POWER_UP)
-        food_count++;
-    }
-  }
-
   ss.str("");
   ss.clear();
-  ss << "Food: " << food_count;
+  ss << "Food: " << game.food;
   drawText(ss.str(), 150, config.windowHeight + 5, 12, sf::Color::Magenta, win);
 }
 


### PR DESCRIPTION
## Description
With this PR ghost movement logic is simplified. The reason of doing it were a nested if-else blocks. The current implementation relies on randomly selecting decision from available options.

The logic promotes directions other then going back. Ghost is changing direction to opposite only when there is no other option.