### PR TITLE
Refactor: Remove duplicated GameState enum (#26)

### DIFF
--- a/src/core/game.h
+++ b/src/core/game.h
@@ -15,8 +15,6 @@ class Renderer;
 
 namespace core {
 
-enum GameState { MENU, PLAYING, INSTRUCTIONS, LEADERBOARD, GAME_OVER, QUIT };
-
 struct SGame {
   Pacman pman;
   SMap map;
@@ -24,7 +22,6 @@ struct SGame {
   int timer;
   int delay;
   int food;
-  GameState state;
 };
 
 void game_count(SGame &game);

--- a/src/core/game_state.cpp
+++ b/src/core/game_state.cpp
@@ -1,10 +1,10 @@
 #include "core/game_state.h"
-#include "core/systems.h"
 #include "core/entity.h"
 #include "core/game.h"
 #include "core/ghost.h"
 #include "core/map.h"
 #include "core/pman.h"
+#include "core/systems.h"
 
 #include <iostream>
 
@@ -25,7 +25,6 @@ public:
         paused(false) {}
 
   void onEnter() override {
-    context.game.state = PLAYING;
     context.level = level;
     context.renderer->clear();
 
@@ -136,7 +135,6 @@ public:
       : IGameState(ctx), reason(std::move(reason)), level(level), won(won) {}
 
   void onEnter() override {
-    context.game.state = GAME_OVER;
     context.renderer->clear();
     context.renderer->showGameOver(reason);
 
@@ -179,7 +177,6 @@ public:
   explicit InstructionsState(GameContext &ctx) : IGameState(ctx) {}
 
   void onEnter() override {
-    context.game.state = INSTRUCTIONS;
     context.renderer->clear();
     context.renderer->showInstructions();
   }
@@ -200,7 +197,6 @@ public:
   explicit LeaderboardState(GameContext &ctx) : IGameState(ctx) {}
 
   void onEnter() override {
-    context.game.state = LEADERBOARD;
     context.renderer->clear();
     context.renderer->showLeaderboard();
   }
@@ -221,7 +217,6 @@ public:
   explicit MainMenuState(GameContext &ctx) : IGameState(ctx) {}
 
   void onEnter() override {
-    context.game.state = MENU;
     context.renderer->clear();
     context.renderer->showMenu();
   }

--- a/src/core/game_state.h
+++ b/src/core/game_state.h
@@ -13,11 +13,10 @@ namespace core {
 
 class GameContext {
 public:
-  GameContext(GameState state, const GameConfig &config,
+  GameContext(const GameConfig &config,
               std::unique_ptr<rendering::Renderer> renderer)
       : config(config), game(), renderer(std::move(renderer)), quit(false),
         level(1) {
-    game.state = state;
     game.delay = config.gameTickDelayMs;
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ int main() {
     return 1;
   }
 
-  core::GameContext context(core::MENU, config, std::move(renderer));
+  core::GameContext context(config, std::move(renderer));
 
   auto state = core::createInitialState(context);
   state->onEnter();


### PR DESCRIPTION
Previously defined GameState enum was not used, as it was replaced by IGameStates implementations. As it is not used, it should be removed.