### PR TITLE
Refactor: Separate concerns between Game and Pacman (#48)

### DIFF
--- a/src/core/entities/entity.h
+++ b/src/core/entities/entity.h
@@ -12,15 +12,26 @@ class Entity {
 public:
   virtual ~Entity() = default;
 
-  virtual int x() const = 0;
-  virtual int y() const = 0;
-  virtual int prev_x() const = 0;
-  virtual int prev_y() const = 0;
-  virtual Direction direction() const = 0;
-  virtual void setPosition(int x, int y) = 0;
-  virtual void setDirection(Direction direction) = 0;
-  virtual void savePreviousPosition() = 0;
+  int x() const { return x_; }
+  int y() const { return y_; }
+  int prev_x() const { return prev_x_; }
+  int prev_y() const { return prev_y_; }
+  Direction direction() const { return direction_; }
+  void setPosition(int x, int y) {
+    x_ = x;
+    y_ = y;
+  }
+  void setDirection(Direction d) { direction_ = d; }
+  void savePreviousPosition() {
+    prev_x_ = x_;
+    prev_y_ = y_;
+  }
+
   virtual TileType move(Map &map) = 0;
+
+protected:
+  int x_ = 0, y_ = 0, prev_x_ = 0, prev_y_ = 0;
+  Direction direction_ = Direction::NONE;
 };
 
 } // namespace core

--- a/src/core/entities/ghost.cpp
+++ b/src/core/entities/ghost.cpp
@@ -5,29 +5,9 @@
 namespace pacman {
 namespace core {
 
-Ghost::Ghost()
-    : last_move(Direction::NONE), xg(0), yg(0), prev_xg(0), prev_yg(0) {}
-
-Ghost::Ghost(int x, int y) : Ghost() { setPosition(x, y); }
-
-int Ghost::x() const { return xg; }
-int Ghost::y() const { return yg; }
-int Ghost::prev_x() const { return prev_xg; }
-int Ghost::prev_y() const { return prev_yg; }
-Direction Ghost::direction() const { return last_move; }
-
-void Ghost::setPosition(int x, int y) {
-  xg = x;
-  yg = y;
-  prev_xg = x;
-  prev_yg = y;
-}
-
-void Ghost::setDirection(Direction direction) { last_move = direction; }
-
-void Ghost::savePreviousPosition() {
-  prev_xg = xg;
-  prev_yg = yg;
+Ghost::Ghost(int x, int y) {
+  setPosition(x, y);
+  savePreviousPosition();
 }
 
 namespace {
@@ -67,18 +47,18 @@ Direction reverseOf(Direction dir) {
 TileType Ghost::move(Map &map) {
   savePreviousPosition();
 
-  Direction reverse = reverseOf(last_move);
+  Direction reverse = reverseOf(direction_);
   std::vector<MovePlan> candidates;
 
   for (const MovePlan &m : ALL_MOVES) {
-    if (m.dir != reverse && isTileAvailable(map, xg + m.dx, yg + m.dy))
+    if (m.dir != reverse && isTileAvailable(map, x_ + m.dx, y_ + m.dy))
       candidates.push_back(m);
   }
 
   // At a dead end allow reversing
   if (candidates.empty()) {
     for (const MovePlan &m : ALL_MOVES) {
-      if (isTileAvailable(map, xg + m.dx, yg + m.dy))
+      if (isTileAvailable(map, x_ + m.dx, y_ + m.dy))
         candidates.push_back(m);
     }
   }
@@ -91,9 +71,9 @@ TileType Ghost::move(Map &map) {
                                ? candidates[0]
                                : candidates[std::rand() % candidates.size()];
 
-  xg += chosen.dx;
-  yg += chosen.dy;
-  last_move = chosen.dir;
+  x_ += chosen.dx;
+  y_ += chosen.dy;
+  direction_ = chosen.dir;
   return TileType::EMPTY;
 }
 

--- a/src/core/entities/ghost.h
+++ b/src/core/entities/ghost.h
@@ -8,21 +8,9 @@ namespace core {
 
 class Ghost : public Entity {
 public:
-  Ghost();
+  Ghost() = default;
   Ghost(int x, int y);
-
-  int x() const override;
-  int y() const override;
-  int prev_x() const override;
-  int prev_y() const override;
-  Direction direction() const override;
-  void setPosition(int x, int y) override;
-  void setDirection(Direction direction) override;
-  void savePreviousPosition() override;
   TileType move(Map &map) override;
-
-  Direction last_move;
-  int xg, yg, prev_xg, prev_yg;
 };
 
 } // namespace core

--- a/src/core/entities/pman.cpp
+++ b/src/core/entities/pman.cpp
@@ -3,64 +3,42 @@
 namespace pacman {
 namespace core {
 
-Pacman::Pacman()
-    : lives(0), points(0), spawnX(0), spawnY(0), xp_(0), yp_(0), prev_xp_(0),
-      prev_yp_(0), direction_(Direction::NONE) {}
-
-int Pacman::x() const { return xp_; }
-int Pacman::y() const { return yp_; }
-int Pacman::prev_x() const { return prev_xp_; }
-int Pacman::prev_y() const { return prev_yp_; }
-Direction Pacman::direction() const { return direction_; }
-
-void Pacman::setPosition(int x, int y) {
-  xp_ = x;
-  yp_ = y;
-}
-
-void Pacman::setDirection(Direction direction) { direction_ = direction; }
-
-void Pacman::savePreviousPosition() {
-  prev_xp_ = xp_;
-  prev_yp_ = yp_;
-}
-
 TileType Pacman::move(Map &map) {
   savePreviousPosition();
 
   if (direction_ == Direction::NONE)
     return TileType::EMPTY;
 
-  int newRow = xp_;
-  int newCol = yp_;
+  int newRow = x_;
+  int newCol = y_;
 
   switch (direction_) {
   case Direction::LEFT:
-    if (xp_ == 8 && yp_ == 0) {
+    if (x_ == 8 && y_ == 0) {
       newCol = 19;
       break;
     }
-    if (!map.isWall(xp_, yp_ - 1))
-      newCol = yp_ - 1;
+    if (!map.isWall(x_, y_ - 1))
+      newCol = y_ - 1;
     break;
 
   case Direction::RIGHT:
-    if (xp_ == 8 && yp_ == 19) {
+    if (x_ == 8 && y_ == 19) {
       newCol = 0;
       break;
     }
-    if (!map.isWall(xp_, yp_ + 1))
-      newCol = yp_ + 1;
+    if (!map.isWall(x_, y_ + 1))
+      newCol = y_ + 1;
     break;
 
   case Direction::UP:
-    if (!map.isWall(xp_ - 1, yp_))
-      newRow = xp_ - 1;
+    if (!map.isWall(x_ - 1, y_))
+      newRow = x_ - 1;
     break;
 
   case Direction::DOWN:
-    if (!map.isWall(xp_ + 1, yp_))
-      newRow = xp_ + 1;
+    if (!map.isWall(x_ + 1, y_))
+      newRow = x_ + 1;
     break;
 
   default:
@@ -68,8 +46,8 @@ TileType Pacman::move(Map &map) {
   }
 
   TileType consumed = map.consumePellet(newRow, newCol);
-  xp_ = newRow;
-  yp_ = newCol;
+  x_ = newRow;
+  y_ = newCol;
   return consumed;
 }
 

--- a/src/core/entities/pman.h
+++ b/src/core/entities/pman.h
@@ -8,29 +8,8 @@ namespace core {
 
 class Pacman : public Entity {
 public:
-  Pacman();
-
-  int x() const override;
-  int y() const override;
-  int prev_x() const override;
-  int prev_y() const override;
-  Direction direction() const override;
-  void setPosition(int x, int y) override;
-  void setDirection(Direction direction) override;
-  void savePreviousPosition() override;
+  Pacman() = default;
   TileType move(Map &map) override;
-
-  int lives;
-  int points;
-  int spawnX;
-  int spawnY;
-
-private:
-  int xp_;
-  int yp_;
-  int prev_xp_;
-  int prev_yp_;
-  Direction direction_;
 };
 
 } // namespace core

--- a/src/core/game/game.cpp
+++ b/src/core/game/game.cpp
@@ -22,13 +22,14 @@ void Game::count() {
 void Game::init(const GameConfig &config) {
   powerUpScore = config.powerUpScore;
   pman = Pacman();
-  pman.spawnX = config.pacmanStartX;
-  pman.spawnY = config.pacmanStartY;
+  spawnX = config.pacmanStartX;
+  spawnY = config.pacmanStartY;
   pman.setPosition(config.pacmanStartX, config.pacmanStartY);
   pman.savePreviousPosition();
   timer = config.startingTimerMs;
   delay = config.gameTickDelayMs;
-  pman.lives = config.startingLives;
+  lives = config.startingLives;
+  points = 0;
   ghosts.clear();
   ghosts.emplace_back(config.ghost1StartX, config.ghost1StartY);
   ghosts.emplace_back(config.ghost2StartX, config.ghost2StartY);
@@ -52,8 +53,7 @@ void Game::saveLeaderboard(const std::string &playerName) const {
   }
   f.close();
 
-  entries.push_back(
-      {playerName.empty() ? "Anonymous" : playerName, pman.points});
+  entries.push_back({playerName.empty() ? "Anonymous" : playerName, points});
 
   sort(entries.begin(), entries.end(),
        [](const auto &a, const auto &b) { return a.second > b.second; });

--- a/src/core/game/game.h
+++ b/src/core/game/game.h
@@ -16,6 +16,10 @@ public:
   Pacman pman;
   Map map;
   std::vector<Ghost> ghosts;
+  int lives;
+  int points;
+  int spawnX;
+  int spawnY;
   int timer;
   int delay;
   int food;

--- a/src/core/states/game_state.cpp
+++ b/src/core/states/game_state.cpp
@@ -89,7 +89,7 @@ public:
 
     context.game.count();
 
-    if (context.game.pman.lives <= 0) {
+    if (context.game.lives <= 0) {
       requestTransition(
           std::make_unique<GameOverState>(context, "lives", level, false));
       return;

--- a/src/core/systems/systems.cpp
+++ b/src/core/systems/systems.cpp
@@ -6,8 +6,8 @@ namespace core {
 void checkCollisions(Game &game) {
   for (const Ghost &ghost : game.ghosts) {
     if (ghost.x() == game.pman.x() && ghost.y() == game.pman.y()) {
-      game.pman.lives--;
-      game.pman.setPosition(game.pman.spawnX, game.pman.spawnY);
+      game.lives--;
+      game.pman.setPosition(game.spawnX, game.spawnY);
       return;
     }
   }
@@ -15,9 +15,9 @@ void checkCollisions(Game &game) {
 
 void applyScoring(Game &game, TileType consumed) {
   if (consumed == TileType::PELLET) {
-    game.pman.points++;
+    game.points++;
   } else if (consumed == TileType::POWER_UP) {
-    game.pman.points += game.powerUpScore;
+    game.points += game.powerUpScore;
   }
 }
 

--- a/src/rendering/cli_renderer.cpp
+++ b/src/rendering/cli_renderer.cpp
@@ -82,9 +82,9 @@ char CLIRenderer::tileTypeToChar(core::TileType type) {
 
 void CLIRenderer::showGameCounter(const core::Game &game) {
   cout << "Time remaining: " << game.timer / 1000 << "\n\n";
-  cout << "Points: " << game.pman.points << "\n\n";
+  cout << "Points: " << game.points << "\n\n";
   cout << "Food count: " << game.food << "\n\n";
-  cout << "Lives: " << game.pman.lives << "\n\n";
+  cout << "Lives: " << game.lives << "\n\n";
 }
 
 void CLIRenderer::showGameOver(const std::string &reason) {

--- a/src/rendering/gui_renderer.cpp
+++ b/src/rendering/gui_renderer.cpp
@@ -191,12 +191,12 @@ void GUIRenderer::drawGameUI(const core::Game &game, sf::RenderWindow &win) {
 
   ss.str("");
   ss.clear();
-  ss << "Points: " << game.pman.points;
+  ss << "Points: " << game.points;
   drawText(ss.str(), 10, config.windowHeight + 25, 12, sf::Color::Cyan, win);
 
   ss.str("");
   ss.clear();
-  ss << "Lives: " << game.pman.lives;
+  ss << "Lives: " << game.lives;
   drawText(ss.str(), 10, config.windowHeight + 45, 12, sf::Color::Yellow, win);
 
   ss.str("");

--- a/tests/core/entities/pman_test.cpp
+++ b/tests/core/entities/pman_test.cpp
@@ -6,18 +6,6 @@ using namespace pacman::core;
 
 static Map makeOpenMap() { return Map(20, 17); }
 
-TEST(PacmanDefaults, InitialLivesAndPoints) {
-  Pacman p;
-  EXPECT_EQ(p.lives, 0);
-  EXPECT_EQ(p.points, 0);
-}
-
-TEST(PacmanDefaults, InitialSpawnCoords) {
-  Pacman p;
-  EXPECT_EQ(p.spawnX, 0);
-  EXPECT_EQ(p.spawnY, 0);
-}
-
 TEST(PacmanDefaults, InitialPosition) {
   Pacman p;
   EXPECT_EQ(p.x(), 0);


### PR DESCRIPTION
Up to this point concerns were mixed between Game and Pacman. Pacman held information about lives, points and spawn positions. The goal of this PR is to move all game-based elements into Game component, which includes game states (timer, points, lives, spawn positions), rules (collision checker, game over conditions), entities and map references.

Additionally, interface for entities were normalized to make naming consistent and share all behavioral concepts (position, direction, move method, etc).